### PR TITLE
Correction of explained variance calculation

### DIFF
--- a/keypy/microstates/parameters.py
+++ b/keypy/microstates/parameters.py
@@ -297,8 +297,8 @@ def compute_mstate_parameters(confobj, eeg, maps, eeg_info_study_obj):
         loading=abs(covm).max(axis=1)
         loading_all=abs(covm_all).max(axis=1)
 
-        b_loading=loading/sqrt(model.shape[1])
-        b_loading_all=loading_all/sqrt(model.shape[1])
+        b_loading=np.square(loading/sqrt(model.shape[1]))
+        b_loading_all=np.square(loading_all/sqrt(model.shape[1]))
         		
         exp_var=sum(b_loading)/sum(epoch[gfp_peak_indices].std(axis=1))
         exp_var_tot=sum(b_loading_all)/sum(epoch.std(axis=1))


### PR DESCRIPTION
As proposed by Reinoud Maex in his pull request, the computation of explained variance was incorrect in KeyPy. If we look back to the source of this equation, Pascual-Marqui 1995, reducing equations 10, 11, and 12, leaves a square of the product of the data and model. KeyPy originally computed this product, but did not square it. This fixes that issue.